### PR TITLE
Fix tests for Pca estimate components

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -145,8 +145,10 @@ class MVA():
             If not None, the results of the decomposition will be projected in
             the selected masked area.
         return_info: bool, default False
-            The result of the decomposition is stored internally. However, some algorithms generate some extra
-            information that is not stored. If True (the default is False) return any extra information if available
+            The result of the decomposition is stored internally. However, 
+            some algorithms generate some extra information that is not 
+            stored. If True (the default is False) return any extra 
+            information if available
 
         Returns
         -------
@@ -238,6 +240,7 @@ class MVA():
             # algorithms
             explained_variance = None
             explained_variance_ratio = None
+            no_significant_components = None
             mean = None
 
             if algorithm == 'svd':
@@ -383,15 +386,14 @@ class MVA():
                 explained_variance_ratio = \
                     explained_variance / explained_variance.sum()
                 no_significant_components = \
-                    self._estimate_elbow_position(
-                            explained_variance_ratio)+ 1
+                    self._estimate_elbow_position(explained_variance_ratio) + 1
 
             # Store the results in learning_results
-
             target.factors = factors
             target.loadings = loadings
             target.explained_variance = explained_variance
             target.explained_variance_ratio = explained_variance_ratio
+            target.no_significant_components = no_significant_components
             target.decomposition_algorithm = algorithm
             target.poissonian_noise_normalized = \
                 normalize_poissonian_noise
@@ -1248,7 +1250,7 @@ class MVA():
         self.data[:] = self._data_before_treatments
         del self._data_before_treatments
 
-    def _estimate_elbow_position(self,error_estimate):
+    def _estimate_elbow_position(self, error_estimate):
         """
         Estimate the elbow position of a curve
         Used to estimate the no of significant components in PCA variance ratio
@@ -1261,14 +1263,14 @@ class MVA():
         Returns
         -------
         elbow position : int
-        
+
         Index of the elbow position (+1)
-        
+
         """
-        maxpoints = min(20,len(error_estimate)-1)
-        # Find a line between first and last point 
+        maxpoints = min(20, len(error_estimate)-1)
+        # Find a line between first and last point
         # With a classic elbow scree plot the line from first to last
-        # more or less defines a triangle 
+        # more or less defines a triangle
         # The elbow should be the point which is the
         # furthest distance from this line
         #
@@ -1276,15 +1278,15 @@ class MVA():
         x2 = maxpoints
         y1 = np.log(error_estimate[0])
         x1 = 0
-        # loop 
+        # loop
         distance = np.zeros((maxpoints))
         for i in range(maxpoints):
             y0 = np.log(error_estimate[i])
-            x0=i
+            x0 = i
             distance[i] = np.abs((x2-x1)*(y1-y0)-(x1-x0)*(y2-y1))\
-            /np.math.sqrt((x2-x1)**2+(y2-y1)**2)  
-            
-        #Point with the largest distance is the "elbow"
+                / np.math.sqrt((x2-x1)**2+(y2-y1)**2)
+
+        # Point with the largest distance is the "elbow"
         elbow_position = np.argmax(distance)
         return elbow_position
 

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -148,9 +148,9 @@ class TestEstimateElbowPosition:
         self.s = s
 
     def test_elbow_position(self):
-        variance = s.learning_results.explained_variance_ratio
+        variance = self.s.learning_results.explained_variance_ratio
         elbow = self.s._estimate_elbow_position(variance)
-        assert elbow = 4
+        assert elbow == 4
 
 
 class TestReverseDecompositionComponent:
@@ -263,7 +263,7 @@ class TestReturnInfo:
         for algorithm in ["svd", "fast_svd"]:
             print(algorithm)
             assert self.s.decomposition(
-                algorithm=algorithm, return_info=True, output_dimension=1) is None
+                algorithm=algorithm, return_info=True, output_dimension=2) is None
 
     # Warning filter can be removed after scikit-learn >= 0.22
     # See sklearn.decomposition.sparse_pca.SparsePCA docstring
@@ -274,13 +274,13 @@ class TestReturnInfo:
             assert self.s.decomposition(
                 algorithm=algorithm,
                 return_info=True,
-                output_dimension=1) is not None
+                output_dimension=2) is not None
         for algorithm in ["sklearn_pca", "nmf",
                           "sparse_pca", "mini_batch_sparse_pca"]:
             assert self.s.decomposition(
                 algorithm=algorithm,
                 return_info=True,
-                output_dimension=1) is not None
+                output_dimension=2) is not None
 
     # Warning filter can be removed after scikit-learn >= 0.22
     # See sklearn.decomposition.sparse_pca.SparsePCA docstring
@@ -291,13 +291,13 @@ class TestReturnInfo:
             assert self.s.decomposition(
                 algorithm=algorithm,
                 return_info=False,
-                output_dimension=1) is None
+                output_dimension=2) is None
         for algorithm in ["sklearn_pca", "nmf",
                           "sparse_pca", "mini_batch_sparse_pca", ]:
             assert self.s.decomposition(
                 algorithm=algorithm,
                 return_info=False,
-                output_dimension=1) is None
+                output_dimension=2) is None
 
 
 class TestNonFloatTypeError:

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -152,6 +152,7 @@ class TestEstimateElbowPosition:
         elbow = self.s._estimate_elbow_position(variance)
         assert elbow == 4
 
+    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_store_number_significant_components(self):
         np.random.seed(1)
         s = signals.Signal1D(np.random.random((20, 100)))

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -143,14 +143,23 @@ class TestEstimateElbowPosition:
 
     def setup_method(self, method):
         s = signals.BaseSignal(np.empty(1))
-        s.learning_results.explained_variance_ratio = np.asarray([10e-1,5e-2,9e-3,1e-3,9e-5,5e-5,3.0e-5,\
-                                                                       2.2e-5,1.9e-5,1.8e-5,1.7e-5,1.6e-5])
+        s.learning_results.explained_variance_ratio = np.asarray([10e-1, 5e-2, 9e-3, 1e-3, 9e-5, 5e-5, 3.0e-5,
+                                                                  2.2e-5, 1.9e-5, 1.8e-5, 1.7e-5, 1.6e-5])
         self.s = s
 
     def test_elbow_position(self):
         variance = self.s.learning_results.explained_variance_ratio
         elbow = self.s._estimate_elbow_position(variance)
         assert elbow == 4
+
+    def test_store_number_significant_components(self):
+        np.random.seed(1)
+        s = signals.Signal1D(np.random.random((20, 100)))
+        s.decomposition()
+        assert s.learning_results.no_significant_components == 2
+        # Check that no_significant_components is reset properly
+        s.decomposition(algorithm='nmf', output_dimension=2)
+        assert s.learning_results.no_significant_components is None
 
 
 class TestReverseDecompositionComponent:
@@ -328,4 +337,5 @@ class TestLoadDecompositionResults:
             self.s.learning_results.load(fname1)
             fname2 = join(tmpdir, "output.hspy")
             self.s.save(fname2)
-            assert isinstance(self.s.learning_results.decomposition_algorithm, str)
+            assert isinstance(
+                self.s.learning_results.decomposition_algorithm, str)


### PR DESCRIPTION
- fix a few tests,
- store the number of significant component and add test,
- reset the number of significant component to `None` when necessary,
- and a bit of formatting.
